### PR TITLE
document fragment option

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "ava": "0.0.4",
+    "jshint": "^2.9.5",
     "precommit-hook": "^1.0.7"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -16,16 +16,25 @@ var metal = require('metal-name');
 
 metal();
 //=> 'Twisted Vengeance'
+
+metal({ fragment: 'start'});
+//=> 'Twisted'
+
+metal({ fragment: 'end' });
+//=> 'Vengeance'
 ```
 
 
 ## API
 
-### metal()
+### metal([options])
 
 Type: `string`
 
 Random heavy metal band name.
+
+Options:
+* `fragment`: With value 'start' or 'end', generate only that part of the name
 
 
 ## CLI


### PR DESCRIPTION
and add missing jshint dev dependency

This was just the right package I needed. Wanted to contribute back a little, figured I start with documenting the undocumented fragment option.